### PR TITLE
Simple span decoration. #2

### DIFF
--- a/lib/opencensus/honeycomb/config.ex
+++ b/lib/opencensus/honeycomb/config.ex
@@ -23,6 +23,7 @@ defmodule Opencensus.Honeycomb.Config do
 
   @default_api_endpoint "https://api.honeycomb.io"
   @default_dataset "opencensus"
+  @default_decorator nil
   @default_service_name "-"
   @default_write_key nil
   @default_batch_size 100
@@ -31,9 +32,15 @@ defmodule Opencensus.Honeycomb.Config do
     :api_endpoint,
     :batch_size,
     :dataset,
+    :decorator,
     :service_name,
     :write_key
   ]
+
+  @typedoc """
+  The module and keyword arguments for your `Opencensus.Honeycomb.Decorator` implementation.
+  """
+  @type decorator :: {module(), keyword()}
 
   @typedoc """
   Our configuration struct.
@@ -41,6 +48,7 @@ defmodule Opencensus.Honeycomb.Config do
   * `api_endpoint`: the API endpoint (default:`#{inspect(@default_api_endpoint)})`
   * `batch_size`: the write key (default:`#{inspect(@default_batch_size)})`
   * `dataset`: the dataset (default:`#{inspect(@default_dataset)})`
+  * `decorator`: the decorator module and arguments (default:`#{inspect(@default_decorator)})`
   * `service_name`: the service name (default:`#{inspect(@default_service_name)}`
   * `write_key`: the write key (default:`#{inspect(@default_write_key)})`
 
@@ -50,6 +58,7 @@ defmodule Opencensus.Honeycomb.Config do
           api_endpoint: String.t() | nil,
           batch_size: integer() | nil,
           dataset: String.t() | nil,
+          decorator: decorator() | nil,
           service_name: String.t() | nil,
           write_key: String.t() | nil
         }
@@ -112,6 +121,7 @@ defmodule Opencensus.Honeycomb.Config do
       api_endpoint: @default_api_endpoint,
       batch_size: @default_batch_size,
       dataset: @default_dataset,
+      decorator: @default_decorator,
       service_name: @default_service_name,
       write_key: @default_write_key
     }

--- a/lib/opencensus/honeycomb/decorator.ex
+++ b/lib/opencensus/honeycomb/decorator.ex
@@ -1,0 +1,15 @@
+defmodule Opencensus.Honeycomb.Decorator do
+  @moduledoc """
+  Behaviour to add data to events before delivery. API not final.
+  """
+
+  alias Opencensus.Honeycomb.Event
+
+  @doc """
+  Transform event data. API not final.
+
+  Takes an `t:Event.event_data/0` (i.e. the span attributes after they've been flattened), and
+  your options. Returns replacment `t:Event.event_data/0`.
+  """
+  @callback decorate(attributes :: Event.event_data(), opts :: keyword()) :: Event.event_data()
+end

--- a/lib/opencensus/honeycomb/event.ex
+++ b/lib/opencensus/honeycomb/event.ex
@@ -97,20 +97,26 @@ defmodule Opencensus.Honeycomb.Event do
   defstruct [:time, :data]
 
   @typedoc """
-  Honeycomb event suitable for POSTing to their batch API.
-
-  * `time`: ms since epoch; [MUST] be in ISO 8601 format, e.g. `"2019-05-17T09:55:12.622658Z"`
-  * `data`: a map of the data to send
+  Span attributes after flattening.
 
   See [attribute limitations](#module-opencensus-honeycomb) for important detail on span attribute
   names and values.
 
-  [MUST]: https://tools.ietf.org/html/rfc2119#section-1
   [attrlimits]: #module-opencensus-honeycomb
+  """
+  @type event_data :: map()
+
+  @typedoc """
+  Honeycomb event suitable for POSTing to their batch API.
+
+  * `time`: ms since epoch; [MUST] be in ISO 8601 format, e.g. `"2019-05-17T09:55:12.622658Z"`
+  * `data`: `t:event_data/0` after flattening.
+
+  [MUST]: https://tools.ietf.org/html/rfc2119#section-1
   """
   @type t :: %__MODULE__{
           time: String.t(),
-          data: map()
+          data: event_data()
         }
 
   @doc """

--- a/lib/opencensus/honeycomb/reporter.ex
+++ b/lib/opencensus/honeycomb/reporter.ex
@@ -26,9 +26,20 @@ defmodule Opencensus.Honeycomb.Reporter do
 
     spans
     |> Enum.map(translate)
+    |> Enum.map(&decorate(&1, config.decorator))
     |> Enum.chunk_every(config.batch_size)
     |> Enum.each(&Sender.send_batch/1)
 
     :ok
+  end
+
+  @doc false
+  @spec decorate(Event.t(), Config.decorator()) :: Event.t()
+  def decorate(event, decorator)
+  def decorate(event, nil), do: event
+
+  def decorate(event, {module, opts}) do
+    data = apply(module, :decorate, [event.data, opts])
+    struct!(event, data: data)
   end
 end

--- a/test/opencensus_honeycomb_config_test.exs
+++ b/test/opencensus_honeycomb_config_test.exs
@@ -52,6 +52,7 @@ defmodule Opencensus.Honeycomb.ConfigTest do
              batch_size: 100,
              write_key: "0000000000000000",
              dataset: "custom_dataset",
+             decorator: nil,
              service_name: "custom_service_name"
            }
   end
@@ -64,6 +65,7 @@ defmodule Opencensus.Honeycomb.ConfigTest do
       batch_size: 23,
       write_key: "custom_write_key",
       dataset: "custom_dataset",
+      decorator: {MyApp.Decorator, []},
       service_name: "custom_service_name"
     }
 
@@ -74,6 +76,7 @@ defmodule Opencensus.Honeycomb.ConfigTest do
              api_endpoint: "https://api-custom.example.com",
              batch_size: 23,
              dataset: "custom_dataset",
+             decorator: {MyApp.Decorator, []},
              service_name: "custom_service_name",
              write_key: "custom_write_key"
            ]
@@ -94,6 +97,7 @@ defmodule Opencensus.Honeycomb.ConfigTest do
              api_endpoint: nil,
              batch_size: nil,
              dataset: nil,
+             decorator: nil,
              service_name: nil,
              write_key: nil
            ]

--- a/test/opencensus_honeycomb_decorator_test.exs
+++ b/test/opencensus_honeycomb_decorator_test.exs
@@ -1,0 +1,43 @@
+defmodule Opencensus.Honeycomb.DecoratorTest do
+  use ExUnit.Case
+
+  alias Opencensus.Honeycomb.Event
+  alias Opencensus.Honeycomb.Reporter
+
+  defmodule MyDecorator do
+    @behaviour Opencensus.Honeycomb.Decorator
+    @impl Opencensus.Honeycomb.Decorator
+    def decorate(data, opts) do
+      data |> Map.merge(opts[:extra_data])
+    end
+  end
+
+  test "no decoration" do
+    original = %Event{
+      time: "2019-06-28T00:40:05.782Z",
+      data: %{
+        "whatever" => 1
+      }
+    }
+
+    assert Reporter.decorate(original, nil) == original
+  end
+
+  test "decoration" do
+    original = %Event{
+      time: "2019-06-28T00:40:05.782Z",
+      data: %{}
+    }
+
+    extra_data = %{
+      "whatever" => 1
+    }
+
+    expected = %Event{
+      time: original.time,
+      data: extra_data
+    }
+
+    assert Reporter.decorate(original, {MyDecorator, extra_data: extra_data}) == expected
+  end
+end


### PR DESCRIPTION
API not final, but will solve my immediate problem of not having vital attributes (branch, commit, deployment environment, etc) added to all events so I can break down outbound request spans by those attributes.