### PR TITLE
Make 1.7 compatible, using old DateTime.now

### DIFF
--- a/lib/opencensus/honeycomb/event.ex
+++ b/lib/opencensus/honeycomb/event.ex
@@ -126,7 +126,7 @@ defmodule Opencensus.Honeycomb.Event do
   """
   @spec now() :: String.t()
   def now() do
-    DateTime.now("Etc/UTC") |> elem(1) |> DateTime.to_iso8601()
+    DateTime.utc_now() |> DateTime.to_iso8601()
   end
 
   # Record for :opencensus.span


### PR DESCRIPTION
DateTime.now is available only in 1.8 and beyond.  I was attempting to honeycomb all the things in our org, which includes some legacy code. 

I believe this behavior should be identical, but works with more 'lixer builds.