### PR TITLE
allow telemetry ~> 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule Opencensus.Honeycomb.MixProject do
       {:licensir, "~> 0.6.0", only: :dev, runtime: false},
       {:mix_test_watch, "~> 1.0.2", only: :dev, runtime: false},
       {:opencensus, "~> 0.9.2"},
-      {:telemetry, "~> 0.4.0"}
+      {:telemetry, "~> 0.4.0 or ~> 1.0"}
     ]
   end
 


### PR DESCRIPTION
:wave: hello!

telemetry now has a v1.0.0 release that marks stability but otherwise is the same as v0.4.3 (see [the changelog](https://github.com/beam-telemetry/telemetry/blob/main/CHANGELOG.md#100))

This PR just loosens up that dependency so projects can use opencensus_honeycomb and telemetry ~> 1.0